### PR TITLE
feat: support "executablePath" option

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -26,6 +26,7 @@ import {
   Cookie,
   Dialog,
   launch,
+  LaunchOptions,
   Page,
 }                       from 'puppeteer'
 import { StateSwitch }  from 'state-switch'
@@ -61,8 +62,9 @@ export interface InjectResult {
 }
 
 export interface BridgeOptions {
-  head?  : boolean,
-  memory : MemoryCard,
+  head?           : boolean,
+  launchOptions?  : LaunchOptions,
+  memory          : MemoryCard,
 }
 
 export class Bridge extends EventEmitter {
@@ -119,8 +121,10 @@ export class Bridge extends EventEmitter {
   public async initBrowser (): Promise<Browser> {
     log.verbose('PuppetPuppeteerBridge', 'initBrowser()')
 
-    const headless = !(this.options.head)
+    const launchOptions = this.options.launchOptions || {}
+    const headless = !(this.options.head || launchOptions.headless)
     const browser = await launch({
+      ...launchOptions,
       args: [
         '--audio-output-channels=0',
         '--disable-default-apps',
@@ -132,6 +136,7 @@ export class Bridge extends EventEmitter {
         '--hide-scrollbars',
         '--mute-audio',
         '--no-sandbox',
+        ...launchOptions.args || [],
       ],
       headless,
     })


### PR DESCRIPTION
在部分 arm 设备上 ```puppeteer``` 目录下 chrome 启动报错，希望支持 ```executablePath``` option, 可以自由指定 ```chromium``` 路径。